### PR TITLE
Refactor references from 'properties' to 'fixedProperties'

### DIFF
--- a/nodes/Attio/Attio.node.ts
+++ b/nodes/Attio/Attio.node.ts
@@ -243,7 +243,7 @@ export class Attio implements INodeType {
 				const operation = this.getNodeParameter('operation', i) as string;
 
 				// Find the operation configuration
-				const operationProperty: any = properties.find(
+				const operationProperty: any = fixedProperties.find(
 					(prop: any) => prop.name === 'operation' &&
 					prop.displayOptions?.show?.resource?.[0] === resource &&
 					prop.options?.find((opt: any) => opt.value === operation)
@@ -279,7 +279,7 @@ export class Attio implements INodeType {
 				};
 
 				// Process parameters based on their routing configuration
-				const allProperties = properties.filter((prop: any) => {
+				const allProperties = fixedProperties.filter((prop: any) => {
 					return prop.displayOptions?.show?.operation?.[0] === operation &&
 						prop.displayOptions?.show?.resource?.[0] === resource;
 				});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "n8n-nodes-<...>",
-  "version": "0.1.0",
+  "name": "n8n-nodes-attio",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n8n-nodes-<...>",
-      "version": "0.1.0",
+      "name": "n8n-nodes-attio",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devlikeapro/n8n-openapi-node": "^0.1.4"


### PR DESCRIPTION
fix: refactor references from 'properties' to 'fixedProperties' in Attio.node.ts to ensure user defined properties are used correctly, to fix https://github.com/itsjustanks/n8n-nodes-attio/issues/1